### PR TITLE
Allowed for the viewing of the prices on index activity without scrolling the whole page

### DIFF
--- a/app/src/main/res/layout/my_gallery.xml
+++ b/app/src/main/res/layout/my_gallery.xml
@@ -1,34 +1,30 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_margin="5dp"
     android:layout_width="wrap_content" android:layout_height="wrap_content">
 
     <TextView
         android:id="@+id/nameText"
-        android:layout_width="102dp"
-        android:layout_height="40dp"
-        android:layout_alignParentTop="true"
-        android:layout_alignParentBottom="true"
-        android:layout_marginTop="326dp"
-        android:layout_marginBottom="365dp"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="8dp"
+        android:layout_marginRight="8dp"
         android:text="@string/name"
-        android:textSize="24sp" />
+        android:textSize="24sp"
+        app:layout_constraintEnd_toStartOf="@+id/PriceText"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
     <TextView
         android:id="@+id/PriceText"
-        android:layout_width="102dp"
-        android:layout_height="40dp"
-        android:layout_alignParentStart="true"
-        android:layout_alignParentLeft="true"
-        android:layout_alignParentTop="true"
-        android:layout_alignParentEnd="true"
-        android:layout_alignParentRight="true"
-        android:layout_alignParentBottom="true"
-        android:layout_marginStart="66dp"
-        android:layout_marginLeft="66dp"
-        android:layout_marginTop="694dp"
-        android:layout_marginEnd="268dp"
-        android:layout_marginRight="268dp"
-        android:layout_marginBottom="634dp"
-        android:text="TextView"
-        android:textSize="24sp" />
-</RelativeLayout>
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginLeft="8dp"
+        android:textSize="24sp"
+        app:layout_constraintStart_toEndOf="@id/nameText"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="TextView" />
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Changed the item view to the correct constraint layout and made the item view not match the height of the parent but match the size of its content